### PR TITLE
No need for the 'std::' qualification

### DIFF
--- a/Beginning C++ 17 source code/Exercises/Chapter 04/Soln4_06.cpp
+++ b/Beginning C++ 17 source code/Exercises/Chapter 04/Soln4_06.cpp
@@ -10,13 +10,13 @@ using std::endl;
 int main()
 {
   int n {};
-  std::cout << "Enter an integer: ";
-  std::cin >> n;
+  cout << "Enter an integer: ";
+  cin >> n;
   
-  std::cout << "The value is " 
+  cout << "The value is " 
     << (n <= 20 ? "not greater than 20" 
 	  : n <= 30 ? "greater than 20 and not greater than 30" 
 	  : n <= 100? "greater than 30 and not exceeding 100"
 	  : "greater than 100")
-    << '.' << std::endl;
+    << '.' << endl;
 }


### PR DESCRIPTION
It's long-winded to add the namespace qualification if you have already used the 'using' instruction.