### PR TITLE
initialize array with odd numbers

### DIFF
--- a/Beginning C++ 17 source code/Exercises/Chapter 06/Soln6_01.cpp
+++ b/Beginning C++ 17 source code/Exercises/Chapter 06/Soln6_01.cpp
@@ -12,7 +12,7 @@ int main()
   const size_t n {50};
   size_t odds[n];
   for (size_t i {}; i < n; ++i)
-    odds[i] = i + 1;
+    odds[i] = 2*i + 1;
 
   const size_t perline {10};
   std::cout << "The numbers are:\n";

--- a/Beginning C++ 17 source code/Exercises/Chapter 06/Soln6_02.cpp
+++ b/Beginning C++ 17 source code/Exercises/Chapter 06/Soln6_02.cpp
@@ -10,7 +10,7 @@ int main()
   const size_t n {50};
   size_t odds[n];
   for (size_t i {}; i < n; ++i)
-    odds[i] = i + 1;
+    odds[i] = 2*i + 1;
 
   const size_t perline {10};
   std::cout << "The numbers are:\n";


### PR DESCRIPTION
Exercise 6-1 and 6-2 tell you to initialize "an array with the first 50 odd (as in not even) numbers." However, the solution given only prints the first 50 numbers, not odd numbers. This pull request  makes the solution print the first 50 odd numbers.